### PR TITLE
Do not call the package manager to install dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,26 +21,28 @@ You can find the most recent specification of the protocol
 
 Installation instructions
 -------------------------
-If you use `pip`_, install pyaxo with::
+Make sure that you have the following::
+
+    sudo apt-get install python-dev # If using Debian/Ubuntu
+    sudo yum install python-devel # If using Fedora
+
+pyaxo also uses `python-gnupg`_, `curve25519-donna`_, and `passlib`_,
+but these packages will be downloaded and installed automatically by
+`pip`_/`setuptools`_.
+
+If you use *pip*, install pyaxo with::
 
     sudo pip install pyaxo
 
+If you use *setuptools*, change to pyaxo's source folder and install
+with::
+
+    sudo python setup.py install
 
 **pyaxo will be ready for use!**
 
-If you do not use *pip*, first make sure that you have the
-following::
-
-    sudo apt-get install python-dev
-
-pyaxo also uses `python-gnupg`_, `curve25519-donna`_, and `passlib`_,
-and if you have *setuptools* installed, these packages will be
-downloaded and installed automatically. You may need some additional
-python modules as well. Check the imports list.
-
-Finally, from pyaxo's source folder, install with::
-
-    sudo python setup.py install
+If you do not use neither of those, you will have to manually install
+each dependency before running the previous command.
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Make sure that you have the following::
     sudo apt-get install python-dev # If using Debian/Ubuntu
     sudo yum install python-devel # If using Fedora
 
-pyaxo also uses `python-gnupg`_, `curve25519-donna`_, and `passlib`_,
+pyaxo also uses `python-gnupg`_, `curve25519-donna`_ and `passlib`_,
 but these packages will be downloaded and installed automatically by
 `pip`_/`setuptools`_.
 
@@ -66,4 +66,5 @@ Bugs, etc. should be reported to the *pyaxo* github `issues page`_.
 .. _`passlib`: https://pypi.python.org/pypi/passlib
 .. _`pip`: https://pypi.python.org/pypi/pip
 .. _`python-gnupg`: https://pypi.python.org/pypi/python-gnupg/
+.. _`setuptools`: https://pypi.python.org/pypi/setuptools
 .. _`Whisper Systems Blog`: https://whispersystems.org/blog/advanced-ratcheting/

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ BASE_DIRECTORY = '/usr/share/pyaxo'
 
 setup(
     name='pyaxo',
-    version='0.4.5',
+    version='0.4.6',
     description='Python implementation of the Axolotl ratchet protocol',
     author='David R. Andersen',
     author_email='k0rx@RXcomm.net',

--- a/setup.py
+++ b/setup.py
@@ -3,38 +3,13 @@ try:
 except ImportError:
     from distutils.core import setup
 
-import platform
 from glob import glob
-from subprocess import call
-
-distro = platform.linux_distribution()[0].lower()
-manager = {
-    'debian': 'apt-get',
-    'ubuntu': 'apt-get',
-    'fedora': 'yum',
-}
-packages = {
-    'python-dev': {'apt-get': 'python-dev', 'yum': 'python-devel'},
-}
-packages_string = ' '.join(packages.keys())
-not_installed = True
-
-if distro in manager:
-    packages_list = []
-    for package in packages:
-        packages_list.append(packages[package][manager[distro]])
-    not_installed = call([manager[distro], 'install', '-y'] + packages_list)
-    packages_string = ' '.join(packages_list)
-
-if not_installed:
-    print 'Cannot verify if all/some of these packages are installed: ' + packages_string + '.You might have to do ' \
-                                                                                            'it manually'
 
 BASE_DIRECTORY = '/usr/share/pyaxo'
 
 setup(
     name='pyaxo',
-    version='0.4.4',
+    version='0.4.5',
     description='Python implementation of the Axolotl ratchet protocol',
     author='David R. Andersen',
     author_email='k0rx@RXcomm.net',


### PR DESCRIPTION
It is better to ask the users to manually install dependencies we cannot install with the regular setup.