### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
-Python implementation of the Axolotl ratchet protocol.
+Python implementation of the Double Ratchet Algorithm.
 ======================================================
 
 Overview
 --------
-The Axolotl ratchet is a protocol (similar to OTR) that
+The Double Ratchet Algorithm is a protocol (similar to OTR) that
 provides for perfect forward secrecy in (a)synchronous
 communications. It uses triple Diffie-Hellman for
 authentication and ECDHE for perfect forward secrecy.
@@ -12,12 +12,12 @@ protocol - providing better forward and future secrecy,
 as well as deniability.
 
 The protocol was developed by Trevor Perrin and Moxie
-Marlinspike. Its chief use currently is in the Whisper Systems
-TextSecure SMS package.
+Marlinspike. Its chief use currently is in the Open Whisper Systems
+Signal package.
 
-A nice writeup of the protocol is on the `Whisper Systems Blog`_.
+A nice writeup of the protocol is on the `Open Whisper Systems Blog`_.
 You can find the most recent specification of the protocol
-`here <https://github.com/trevp/axolotl/wiki/newversion>`_.
+`here <https://whispersystems.org/docs/specifications/doubleratchet/>`_.
 
 Installation instructions
 -------------------------
@@ -53,7 +53,7 @@ them yet, but it should be straightforward.
 
 Protocol Update
 ---------------
-pyaxo 0.4 was updated according to the latest (Oct 1, 2014) version
+pyaxo 0.4 was updated according to the Oct 1, 2014 version
 of the protocol, which changed the order of the ratcheting. For that
 reason, old conversations (created with pyaxo < 0.4) might not work
 properly after the update. We suggest that users update pyaxo and
@@ -66,4 +66,4 @@ Bugs, etc. should be reported to the *pyaxo* github `issues page`_.
 .. _`pynacl`: https://pypi.python.org/pypi/PyNaCl/
 .. _`pip`: https://pypi.python.org/pypi/pip
 .. _`setuptools`: https://pypi.python.org/pypi/setuptools
-.. _`Whisper Systems Blog`: https://whispersystems.org/blog/advanced-ratcheting/
+.. _`Open Whisper Systems Blog`: https://whispersystems.org/blog/advanced-ratcheting/


### PR DESCRIPTION
Changed "Whisper Systems" to "Open Whisper Systems".

The "Axolotl ratchet" was renamed as the "Double Ratchet Algorithm" in March 2016: https://github.com/trevp/double_ratchet/wiki/Home/_compare/6fa4a516b01327d736df1f52014d8b561a18189a...ab41721f9ed7ca0bdac3e24ce9fc573750e0614d

The most recent specification is located at: https://whispersystems.org/docs/specifications/doubleratchet/. Note that the Oct 1, 2014 version is no longer the latest version.