### PR TITLE
Fix failing installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,11 @@ Installation instructions
 -------------------------
 Make sure that you have the following::
 
-    sudo apt-get install python-dev libffi-dev # If using Debian/Ubuntu
-    sudo yum install python-devel redhat-rpm-config libffi-devel # If using Fedora
+    # If using Debian/Ubuntu
+    sudo apt-get install gcc libffi-dev libsodium-dev python-dev
+
+    # If using Fedora
+    sudo yum install gcc libffi-devel libsodium-devel python-devel redhat-rpm-config
 
 pyaxo also uses `pynacl`_ and `passlib`_,
 but these packages will be downloaded and installed automatically by

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,7 @@ except ImportError:
     from distutils.core import setup
 
 import versioneer
-from glob import glob
 
-
-BASE_DIRECTORY = '/usr/share/pyaxo'
 
 setup(
     name='pyaxo',
@@ -23,12 +20,5 @@ setup(
     install_requires=[
         'passlib>=1.6.1',
         'pynacl>=1.0.1',
-    ],
-    data_files=[
-        (BASE_DIRECTORY + '/examples', glob('examples/*')),
-        (BASE_DIRECTORY + '/tests', glob('tests/*')),
-        (BASE_DIRECTORY + '/utilities', glob('utilities/*')),
-        (BASE_DIRECTORY, ['COPYING']),
-        (BASE_DIRECTORY, ['README.rst']),
     ],
 )


### PR DESCRIPTION
These changes fix pyaxo's setup that was failing in the following scenarios:

- Installing in a virtual environment (attempting to install examples/tests/etc outside of the scope)
- Missing GCC and libsodium developer headers (GCC is a bit obvious but it wouldn't hurt to add)

I uploaded to **testpypi** and it worked. Let me know how your tests go!