### PR TITLE
Sync methods with a decorator

### DIFF
--- a/pyaxo.py
+++ b/pyaxo.py
@@ -317,6 +317,7 @@ class Axolotl(object):
 class AxolotlConversation:
     def __init__(self, axolotl, keys, mode, staged_hk_mk=None):
         self._axolotl = axolotl
+        self.lock = Lock()
         self.keys = keys
         self.mode = mode
         self.staged_hk_mk = staged_hk_mk or dict()
@@ -407,6 +408,7 @@ class AxolotlConversation:
         ckp = hash_(ckp + '1')
         return ckp, mk
 
+    @sync
     def encrypt(self, plaintext):
         if self.ratchet_flag:
             self.keys['DHRs_priv'], self.keys['DHRs'] = generate_keypair()
@@ -432,6 +434,7 @@ class AxolotlConversation:
         self.keys['CKs'] = hash_(self.keys['CKs'] + '1')
         return msg
 
+    @sync
     def decrypt(self, msg):
         pad = msg[HEADER_LEN-HEADER_PAD_NUM_LEN:HEADER_LEN]
         pad_length = ord(pad)


### PR DESCRIPTION
While I was making some changes to unMessage, I had to use a `Lock` for encryption because I removed the queue that synchronized it. I noticed it would be useful to leave it up to pyaxo to sync these methods so that applications would not have to worry about it.

I made a `@sync` decorator to use the instance's own `lock` attribute so that we do not even have to move code into `with` blocks. Do you think that would be useful?

Thanks!